### PR TITLE
Update deploy commands to have elevated sudo

### DIFF
--- a/.ebextensions/01_deploy.config
+++ b/.ebextensions/01_deploy.config
@@ -18,11 +18,11 @@ container_commands:
     command: "mv /tmp/.env /var/app/staging/.env"
 
   01_install_composer_dependencies:
-    command: "php /usr/bin/composer.phar install --no-dev --no-interaction --prefer-dist --optimize-autoloader"
+    command: "sudo php /usr/bin/composer.phar install --no-dev --no-interaction --prefer-dist --optimize-autoloader"
     cwd: "/var/app/staging"
 
   02_install_node_dependencies:
-    command: "npm install"
+    command: "sudo npm install"
     cwd: "/var/app/staging"
 
   03_build_node_assets:


### PR DESCRIPTION
composer install and npm install requires elevated access. So prefixing them with sudo...

Tested on AMI `PHP 7.4 running on 64bit Amazon Linux 2/3.0.1`